### PR TITLE
Add storage modifier to file.

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -60,7 +60,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: #CDD3DE;
 }
 
-.keyword, .storage.type {
+.keyword, .storage.modifier, .storage.type {
   color: #C594C5;
 }
 

--- a/styles/base.less
+++ b/styles/base.less
@@ -60,7 +60,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: #CDD3DE;
 }
 
-.keyword, .storage.modifier, .storage.type {
+.keyword, .storage.modifier, .storage.type, .entity.name.type {
   color: #C594C5;
 }
 


### PR DESCRIPTION
This makes storage modifiers (ie `var`, `let`) the same color as storage types (`class`). Already implemented in sublime version as seen below.

![image](https://cloud.githubusercontent.com/assets/4370652/7192100/7c30b3d8-e460-11e4-8018-e7a1872151e8.png)
