### PR TITLE
Fixed wrap guide, indent guide and invisible characters colors

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -24,7 +24,8 @@ atom-text-editor .wrap-guide, :host .wrap-guide {
 }
 
 atom-text-editor .indent-guide, :host .indent-guide {
-  color: @syntax-indent-guide-color;
+  border-left: 1px dotted @syntax-indent-guide-color;
+  box-shadow: none;
 }
 
 atom-text-editor .invisible-character, :host .invisible-character {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -8,9 +8,9 @@
 @syntax-background-color: #1B2B34;
 
 // Guide colors
-@syntax-wrap-guide-color: #65737e;
-@syntax-indent-guide-color: #65737e;
-@syntax-invisible-character-color: #65737e;
+@syntax-wrap-guide-color: #48555D;
+@syntax-indent-guide-color: #35434b;
+@syntax-invisible-character-color: #4B535B;
 
 // For find and replace markers
 @syntax-result-marker-color: #65737e;


### PR DESCRIPTION
Currently those colors are too bright and do not look like those in [voronianski/oceanic-next-color-scheme](https://github.com/voronianski/oceanic-next-color-scheme).

This fixes it: 
![Screenshot](http://i.imgur.com/WCciIgI.png)
