### PR TITLE
Match the styles of class names and punctuations

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -61,11 +61,11 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: #CDD3DE;
 }
 
-.keyword, .storage.modifier, .storage.type, .entity.name.type {
+.keyword, .storage.modifier, .storage.type {
   color: #C594C5;
 }
 
-.keyword.operator, .constant.other.color, .punctuation, .meta.tag, .punctuation.definition.tag, .punctuation.separator.inheritance.php, .punctuation.definition.tag.html, .punctuation.definition.tag.begin.html, .punctuation.definition.tag.end.html {
+.keyword.operator, .constant.other.color, .punctuation, .punctuation.string, .meta.tag, .punctuation.definition.tag, .punctuation.separator.inheritance.php, .punctuation.definition.tag.html, .punctuation.definition.tag.begin.html, .punctuation.definition.tag.end.html {
   color: #5FB3B3;
 }
 
@@ -85,11 +85,11 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: #F99157;
 }
 
-.string, .constant.other.symbol, .entity.other.inherited-class, .markup.heading, .markup.inserted.git_gutter {
+.string, .variable.quoted.elixir, .constant.other.symbol, .entity.other.inherited-class, .markup.heading, .markup.inserted.git_gutter {
   color: #99C794;
 }
 
-.entity.name.class, .entity.name.type.class, .support.type, .support.class, .support.orther.namespace.use.php, .meta.use.php, .support.other.namespace.php, .markup.changed.git_gutter {
+.variable.constant.elixir, .entity.name.type, .entity.name.class, .entity.name.type.class, .support.type, .support.class, .support.orther.namespace.use.php, .meta.use.php, .support.other.namespace.php, .markup.changed.git_gutter {
   color: #FAC863;
 }
 
@@ -133,6 +133,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
 .constant.character.escape {
   color: #5FB3B3;
 }
+
 .constant.character.escape.css, .constant.character.escape.scss  {
   color: #99C794;
 }


### PR DESCRIPTION
Make the class names more consistent across different languages.
Change the colors of the punctuations in the strings to 5FB3B3
