### PR TITLE
Fix rendering of Markdown on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Based on the textmate theme by Voronianski [https://github.com/voronianski/ocean
 
 ## Screenshots
 
-###SCSS
+### SCSS
 ![image](https://raw.githubusercontent.com/smlombardi/oceanic-next-syntax/master/screenshots/scss.png)
 
-###HTML
+### HTML
 ![image](https://raw.githubusercontent.com/smlombardi/oceanic-next-syntax/master/screenshots/html.png)
 
-###JS
+### JS
 ![image](https://raw.githubusercontent.com/smlombardi/oceanic-next-syntax/master/screenshots/js.png)


### PR DESCRIPTION
The headers for the images weren't displaying properly. You need a space after the '###'s.