### PR TITLE
add .syntax--meta.syntax--class for theme to apply color

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -130,6 +130,7 @@ atom-text-editor.is-focused .line.cursor-line {
 .syntax--entity.syntax--name.syntax--type.syntax--class,
 .syntax--support.syntax--type,
 .syntax--support.syntax--class,
+.syntax--meta.syntax--class,
 .syntax--support.orther.syntax--namespace.syntax--use.syntax--php,
 .syntax--meta.syntax--use.syntax--php,
 .syntax--support.syntax--other.syntax--namespace.syntax--php,


### PR DESCRIPTION
#FAC863 color doesn't apply to the elements which have '**syntax--meta syntax--class**' classes because there aren't any css declarations on base.less file so I added them to it.

Before
<img width="451" alt="screen shot 2018-12-04 at 21 16 14" src="https://user-images.githubusercontent.com/20987496/49465184-fc8a8580-f80d-11e8-89ef-25d6d9eecfa4.png">

After
<img width="401" alt="screen shot 2018-12-04 at 21 36 00" src="https://user-images.githubusercontent.com/20987496/49465196-0613ed80-f80e-11e8-805e-92f2349f67b3.png">

Edit: I have just realized that this might not be the styling that you want so please take it as a recommendation.
